### PR TITLE
feat: GitHub ActionsでCloudflareへの自動デプロイを追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+name: Deploy to Cloudflare
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy-backend:
+    name: Deploy Backend to Cloudflare Workers
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+          
+      - name: Install dependencies
+        working-directory: ./donation-management/donation-management-back
+        run: pnpm install
+        
+      - name: Deploy to Cloudflare Workers
+        working-directory: ./donation-management/donation-management-back
+        run: pnpm run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  deploy-frontend:
+    name: Deploy Frontend to Cloudflare Pages
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+          
+      - name: Install dependencies
+        working-directory: ./donation-management/donation-management-front
+        run: pnpm install
+        
+      - name: Build
+        working-directory: ./donation-management/donation-management-front
+        run: pnpm run build
+        
+      - name: Deploy to Cloudflare Pages
+        working-directory: ./donation-management/donation-management-front
+        run: pnpm run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- リリース時にdonation-management-backをCloudflare Workersに自動デプロイ
- リリース時にdonation-management-frontをCloudflare Pagesに自動デプロイ
- pnpmとNode.js 20を使用した環境設定

## 設定が必要な項目
- GitHubリポジトリのSecretsに`CLOUDFLARE_API_TOKEN`を追加する必要があります

## Test plan
- [ ] GitHubリポジトリにCLOUDFLARE_API_TOKENシークレットを設定
- [ ] テストリリースを作成してデプロイが正常に動作することを確認
- [ ] フロントエンドとバックエンドの両方が正常にデプロイされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)